### PR TITLE
Add AI study to working papers; make paper/ folder pitch-ready

### DIFF
--- a/2 - Working Papers.md
+++ b/2 - Working Papers.md
@@ -1,3 +1,8 @@
+#### Measuring AI's Economic Impact on Household Financial Health
+* If AI breaks parts of the labor market, the first place it shows up isn't GDP. It's households. The official data confirms it quarters late, after the stress has already worked through people's savings and credit. This project builds a state by occupation leading indicator that joins occupational AI-exposure to household financial-stress signals, asking a simple question: do the workers most exposed to AI show financial stress before the BLS catches it, and where?
+* We build the exposure layer from published indices (Felten, Eloundou, Brynjolfsson) mapped to states with BLS OEWS employment shares, add an AI-distress search ontology on top of the running FinMango Financial Health Barometer, and test whether the combined signal leads realized occupational unemployment by one to three months. Pre-registered, open data, MIT licensed.
+* Positioning brief and full research plan are in the repo: AI_ECONOMIC_IMPACT_2026.md and the paper/ folder.
+
 #### Predictive Signals: Do Mental Health-Related Google Searches Reflect Eviction Trends in Real Estate?
 * with Eren Cifi, PhD - Austin Peay State University
 

--- a/paper/08-submission/venue-plan.md
+++ b/paper/08-submission/venue-plan.md
@@ -1,28 +1,33 @@
-# Step 8. Venue, Co-author, Timeline
+# Step 8. Publication and Collaboration
 
 We can plan this now. We run it last.
 
-## 8.1 The venue ladder (working paper first, journal after)
+## 8.1 Where this could go
 
-| Stage | Where | Why | The catch |
-|---|---|---|---|
-| 1, first | arXiv, SSRN, or NBER working paper | citable right away, no review gate, fits how we work | NBER needs an affiliated co-author |
-| 2 | A data or methods journal. Scientific Data, or the Journal of Economic and Social Measurement | rewards the pipeline and the validated method | peer review |
-| 2, other path | Applied econ or policy. Brookings, a labor journal | rewards the labor-economics framing | peer review |
-| 3, if we get one clean result | A short letter, PNAS-style | fastest, tightly scoped | very selective |
+A few honest options, depending on how the result lands.
 
-The plan: post a working paper the moment step 5 clears, then upgrade it.
+- A working paper first (arXiv, SSRN, or an NBER series). It's citable right
+  away and it fits how we already work, open and in public.
+- A data or methods journal, the kind that rewards a documented pipeline and a
+  validated measure.
+- An applied economics or policy outlet, if the labor-market framing is the
+  part that carries.
+- A short letter format, if the result turns out clean and tightly scoped.
 
-## 8.2 Co-author (we should really do this)
+We'll let the result pick the home. A null result and a strong positive result
+don't belong in the same place.
 
-The econometrics load is real, and so is the scrutiny on causation. A co-author
-from the network we already have raises both the quality and the odds.
+## 8.2 Collaboration
 
-- Harvard JCHS. They're already our housing anchor. Natural fit.
-- World Bank or IMF research contacts.
-- An academic labor economist who knows search nowcasting or AI-exposure.
+This work is better with the right people on it. The econometrics is real, and
+so is the scrutiny that comes with anything touching causation, so a co-author
+who knows this terrain raises both the quality and the odds.
 
-Action: pick two or three names, send them the brief and this folder, get a yes.
+We'd welcome collaborators working in housing and financial health, development
+economics, and labor economics, especially anyone close to search-based
+nowcasting or AI-exposure measurement. The positioning brief and this folder
+lay out the whole plan in the open. If it's the kind of thing you want to build
+on, we'd love to talk.
 
 ## 8.3 Rough timeline (at the 1.5 to 2 FTE from brief section 7)
 


### PR DESCRIPTION
Two related changes, both aimed at making the public repo ready to show academics.

## 1. Working papers entry
Adds the AI economic impact study to `2 - Working Papers.md`, in the same short abstract-style format as the other entries (no em dashes). Points readers to the positioning brief and the `paper/` research plan. Placed at the top as a flagship effort.

## 2. Reframe the submission plan for a public audience
`paper/` is public, and we'll be pitching some of the exact people the old `08-submission/venue-plan.md` named. So:
- Dropped the named co-author targets (institutions) and the "pick names, get a yes" recruitment phrasing.
- Rewrote the collaboration section as a general, welcoming open invitation.
- Neutralized the venue language (no "ladder / upgrade / fastest / very selective").

Deliberately left untouched: the candor elsewhere in `paper/` (pre-registered kill condition, "a null result is still a paper," named open problems). That intellectual honesty reads as a credibility asset to academics, not a liability.

https://claude.ai/code/session_01HsRopnzfJHmMjAPFp3Txw6