### PR TITLE
Reframe literature novelty: search input + lead test; add Frank et al. (2025)

### DIFF
--- a/paper/01-claim/claim.md
+++ b/paper/01-claim/claim.md
@@ -23,11 +23,18 @@ What we have to nail down:
 
 Three or four bullets, no more. First pass:
 
-- A new measure. Nobody has joined occupational AI-exposure to household
-  financial-stress signals (search, housing, food) at the state by occupation
-  level. The exposure half exists already. The join doesn't. That's ours.
-- We validate it as a leading indicator. We test whether the signal gets ahead
-  of realized occupational unemployment, and we set the kill condition first.
+- A new input. Our signal is built from high-frequency household
+  financial-stress search behavior (search, housing, food), not from exposure
+  scores or realized unemployment claims. The exposure half exists already.
+  Frank, Ahn and Moro (2025) even joined exposure to state-by-occupation
+  unemployment risk already, so that join is not ours to claim. The
+  search-based distress input is what's new.
+- The leading-indicator test. This is our cleanest claim. Everyone in this
+  space measures contemporaneously or looks backward. We test whether the
+  signal leads realized occupational unemployment by one to three months, and
+  we set the kill condition first. Frank et al. stop in 2019, before ChatGPT.
+  We work in the generative-AI period and ask whether the signal gets ahead of
+  the realized data.
 - It's open. Public, reproducible pipeline and dataset under MIT, built on the
   Barometer we already run.
 - And if we can manage it, a real handle on augmentation versus substitution.
@@ -37,6 +44,8 @@ Three or four bullets, no more. First pass:
 
 - Not a causal paper. We never say AI caused anyone's distress.
 - Not a new exposure index. We combine ones that already exist.
+- Not the first to join exposure to state-by-occupation unemployment. Frank et
+  al. did that. We add the search signal and the lead test.
 - Not policy, not UBI. Not our lane, same as section 6 of the brief.
 
 ## 1.4 The "so what"

--- a/paper/02-literature/literature-map.md
+++ b/paper/02-literature/literature-map.md
@@ -7,10 +7,16 @@ that nobody else does. Figure on 20 to 25 focused reads across three areas.
 
 Plenty of people measure AI exposure, meaning which jobs are at risk. A few
 recent papers measure the effects that already landed (the Stanford Canaries
-work, Anthropic's observed-exposure measure). And there's a whole separate
-literature that nowcasts unemployment from Google Trends. But nobody has joined
-occupational AI-exposure to household financial-stress signals at the state by
-occupation level and tested it as a leading indicator. That join is the paper.
+work on payroll, Anthropic's observed-exposure measure on the CPS). One paper
+gets closest to us: Frank, Ahn and Moro (2025) join AI-exposure scores to
+state-by-occupation unemployment risk and find that an ensemble predicts it.
+But they use exposure scores against realized unemployment claims, they treat
+it contemporaneously, and their data stops in 2019. Separately, a long
+literature nowcasts unemployment from Google Trends, and some of it finds that
+distress-related searches lead jobless claims. Nobody has put the two
+together: a high-frequency household financial-stress search signal, tested as
+a leading indicator of occupational unemployment in the generative-AI period.
+That's the paper.
 
 ## 2.2 Three areas to cover
 
@@ -23,18 +29,30 @@ occupation level and tested it as a leading indicator. That join is the paper.
 - Acemoglu (2025), Economic Policy 40(121):13 to 58. Aggregate TFP is modest.
 
 ### B. The effects that already landed (the new neighbors, read these closely)
+- Frank, Ahn and Moro (2025), PNAS Nexus 4(4):pgaf107, arXiv:2308.02624. THE
+  CLOSEST NEIGHBOR. Joins AI-exposure scores to state-by-occupation unemployment
+  risk (UI claims, 2010 to 2019). Ensemble of exposure scores beats baseline by
+  about 18 points. No search signal, no lead-lag test, pre-ChatGPT. This is the
+  paper our related-work paragraph has to distinguish from most carefully.
 - Brynjolfsson, Chandar and Chen (2025), Canaries in the Coal Mine (Stanford
   Digital Economy Lab). About a 16% relative drop for ages 22 to 25 in exposed
   jobs.
 - Massenkoff and McCrory (2026), Labor market impacts of AI (Anthropic Economic
-  Index). This is the closest thing to what we're doing. Observed exposure from
-  usage and capability, automation-weighted, about 800 O\*NET occupations.
+  Index). An exposure neighbor, but occupation-level only with no state
+  dimension, and contemporaneous, not our closest. Observed exposure from usage
+  and capability, automation-weighted, about 800 O\*NET occupations.
 - Anthropic Economic Index reports (Sept 2025 geographic, Jan 2026, Mar 2026).
 - HBS Working Paper 25-039, Displacement or Complementarity? Still to read.
 
 ### C. Search-based nowcasting (the method precedent, still to read)
 - Choi and Varian (2012), Predicting the Present with Google Trends. The seed.
 - D'Amuri and Marcucci, Google Trends for unemployment forecasting. Track down.
+- [authors TO VERIFY] (2023). "Nowcasting Unemployment Using Neural Networks and
+  Multi-Dimensional Google Trends Data." Economies 11(5):130, MDPI. Finds that
+  searches like "Unemployment" and "Severance Pay" surged before initial jobless
+  claims, and that distress keywords beyond pure job-search terms (mental health,
+  consumption, and so on) improve forecasting. Useful precedent that search can
+  lead claims, and that a multi-dimensional distress ontology helps.
 - Add: recent Google Health Trends methodology and the privacy/aggregation work.
 - Add: divergence-from-baseline and anomaly-detection refs for the section 3.2
   normalization.
@@ -44,8 +62,10 @@ occupation level and tested it as a leading indicator. That join is the paper.
 | Cite | Area | Takeaway | How it relates to our claim | Read? |
 |---|---|---|---|---|
 | Choi and Varian 2012 | C | | search to labor nowcasting works | no |
-| Massenkoff and McCrory 2026 | B | observed-exposure method | we reuse exposure, add the financial-stress join | no |
-| Canaries 2025 | B | the effect is real but late | our signal aims to get ahead of it | no |
+| Massenkoff and McCrory 2026 | B | observed-exposure method | exposure neighbor, but occupation-level only, contemporaneous, null result; not our closest | yes |
+| Canaries 2025 | B | the effect is real but late | our signal aims to get ahead of it | yes |
+| Frank, Ahn and Moro 2025 | B | exposure ensemble predicts state-by-occupation UI risk | closest neighbor; we add the search input and the lead test | yes |
+| [authors TO VERIFY] 2023 (Economies 11(5):130) | C | distress searches lead jobless claims; multi-dim ontology helps | method precedent for our search signal | no |
 | | | | | |
 
 ## 2.4 The related-work paragraph

--- a/paper/02-literature/literature-map.md
+++ b/paper/02-literature/literature-map.md
@@ -47,10 +47,11 @@ That's the paper.
 ### C. Search-based nowcasting (the method precedent, still to read)
 - Choi and Varian (2012), Predicting the Present with Google Trends. The seed.
 - D'Amuri and Marcucci, Google Trends for unemployment forecasting. Track down.
-- [authors TO VERIFY] (2023). "Nowcasting Unemployment Using Neural Networks and
-  Multi-Dimensional Google Trends Data." Economies 11(5):130, MDPI. Finds that
-  searches like "Unemployment" and "Severance Pay" surged before initial jobless
-  claims, and that distress keywords beyond pure job-search terms (mental health,
+- Grybauskas, Pilinkienė, Lukauskas, Stundžienė and Bruneckienė (2023).
+  "Nowcasting Unemployment Using Neural Networks and Multi-Dimensional Google
+  Trends Data." Economies 11(5):130, MDPI. Finds that searches like
+  "Unemployment" and "Severance Pay" surged before initial jobless claims, and
+  that distress keywords beyond pure job-search terms (mental health,
   consumption, and so on) improve forecasting. Useful precedent that search can
   lead claims, and that a multi-dimensional distress ontology helps.
 - Add: recent Google Health Trends methodology and the privacy/aggregation work.
@@ -65,7 +66,7 @@ That's the paper.
 | Massenkoff and McCrory 2026 | B | observed-exposure method | exposure neighbor, but occupation-level only, contemporaneous, null result; not our closest | yes |
 | Canaries 2025 | B | the effect is real but late | our signal aims to get ahead of it | yes |
 | Frank, Ahn and Moro 2025 | B | exposure ensemble predicts state-by-occupation UI risk | closest neighbor; we add the search input and the lead test | yes |
-| [authors TO VERIFY] 2023 (Economies 11(5):130) | C | distress searches lead jobless claims; multi-dim ontology helps | method precedent for our search signal | no |
+| Grybauskas et al. 2023 (Economies 11(5):130) | C | distress searches lead jobless claims; multi-dim ontology helps | method precedent for our search signal | no |
 | | | | | |
 
 ## 2.4 The related-work paragraph


### PR DESCRIPTION
## Why

The close-neighbor lit check turned up the single closest neighbor that was missing from our map: Frank, Ahn and Moro (2025), who already joined AI-exposure scores to state-by-occupation unemployment risk. That means the old "nobody has joined exposure to state-by-occupation data" claim no longer holds. The gap is still open, just narrower. The defensible novelty is now two things Frank et al. and everyone else leave untouched: the high-frequency household financial-stress search input, and the leading-indicator test.

The claim sentence itself does not change. The one-to-three-month lead is still the claim. Only the novelty framing changes. Scope was limited to steps 01 and 02 plus a README scan.

## What changed

**`paper/01-claim/claim.md`**
- 1.2: swapped the "new measure / nobody has joined" and "leading indicator" bullets for "a new input" (search-based distress, not exposure scores or realized claims) and "the leading-indicator test", crediting Frank et al. for the join we no longer claim.
- 1.3: added a bullet noting we are not first to join exposure to state-by-occupation unemployment.

**`paper/02-literature/literature-map.md`**
- 2.1: rewrote the gap paragraph around Frank et al. as the closest neighbor and the "nobody has put the two together" framing.
- 2.2: added Frank et al. as THE CLOSEST NEIGHBOR atop area B; added the Grybauskas et al. (2023) Google Trends distress-terms paper to area C.
- 2.3: fixed the Massenkoff and Canaries rows (read status, relation), added Frank et al. and Grybauskas et al. rows.

**`paper/README.md`**
- Scanned for the old "first to join" framing. None present, so left unchanged.

## Citation verified

The Google Trends paper was first added with a TO VERIFY author marker. Authors are now confirmed against the RePEc record (handle v11y2023i5p130-d1132215) plus corroborating search results: Grybauskas, Pilinkienė, Lukauskas, Stundžienė and Bruneckienė (2023), Economies 11(5):130. No TO VERIFY markers remain.

## One judgment call to flag

In 2.2 area B, the brief only asked me to add Frank et al. and fix the 2.3 table row for Massenkoff and McCrory. But the 2.2 Massenkoff bullet still read "This is the closest thing to what we're doing", which directly contradicts the new Frank et al. "THE CLOSEST NEIGHBOR" line a few rows above. I changed only that one sentence to "An exposure neighbor, but occupation-level only with no state dimension, and contemporaneous, not our closest." Happy to revert if you'd rather keep the brief's literal scope.

https://claude.ai/code/session_011x34oSF8cJqM4sVFZTJt2u

---
_Generated by [Claude Code](https://claude.ai/code/session_011x34oSF8cJqM4sVFZTJt2u)_