### PR TITLE
Lock the claim and fill in Steps 1-3 desk work

### DIFF
--- a/paper/01-claim/claim.md
+++ b/paper/01-claim/claim.md
@@ -3,21 +3,37 @@
 One sentence. Falsifiable. Everything after it answers to it. If a result
 wouldn't change whether that sentence is true, it doesn't go in the paper.
 
-## 1.1 The claim (edit this until it's right)
+## 1.1 The claim (locked)
 
-> A search-behavior plus AI-exposure signal leads realized occupational
-> unemployment by ___ months in high-exposure occupations across US states,
-> with [statistic] of at least [threshold].
+> In the generative-AI period, a combined AI-exposure and household
+> financial-stress search signal at month t leads realized occupational
+> unemployment at month t+k, for k of 1 to 3 months, among high-exposure
+> occupations across US states.
 
-What we have to nail down:
+The falsifiable number behind it: in a panel regression of occupational
+unemployment at t+k on the standardized signal at t, the sum of the
+distributed-lead coefficients over k of 1, 2 and 3 is positive at the 5 percent
+level. We report it next to the lead-lag cross-correlation by k and an
+out-of-sample comparison against an autoregressive baseline.
 
-- The lead window. One to three months? Whatever we pick goes in the
-  pre-registration and we don't move it later.
-- The outcome series. BLS occupational unemployment, LAUS, or CPS.
-- What "high exposure" means. Top third or top quarter of the section 3.1
-  composite.
-- The headline number. Cross-correlation at lag k, a Granger-style test, or how
-  much we beat a no-signal nowcast.
+The decisions, now locked. These flow straight into the pre-registration and we
+don't move them later.
+
+- Lead window. k of 1, 2 and 3 months. The primary test is the distributed-lead
+  specification over all three at once, and we report each k. No picking the
+  best k after the fact.
+- Outcome series. The unemployment rate for each state, occupation cluster, and
+  month, from CPS microdata (IPUMS-CPS), on a 3-month rolling basis to tame the
+  sampling noise, with thin cells suppressed below the pre-registered floor.
+  LAUS state unemployment and national unemployment by occupation cluster are
+  the robustness brackets. CPS is the only public series that is monthly and
+  occupational at once: OEWS is annual, LAUS is not occupational.
+- High exposure. Top tercile of the composite exposure score (Felten, Eloundou,
+  Brynjolfsson, z-scored and equal-weighted), employment-weighted across
+  detailed occupations. The bottom tercile is the placebo comparison (H2).
+- Headline statistic. The distributed-lead coefficient sum above, with
+  state-by-cluster and month fixed effects and standard errors clustered by
+  state and by occupation cluster.
 
 ## 1.2 What's actually new
 
@@ -57,4 +73,4 @@ Result comes back null? Still a paper. A careful negative result that bounds how
 much search behavior can tell us about displacement is worth publishing. Write
 that down now. It's the thing that makes pre-registering safe.
 
-Status: draft / reviewed with co-author / locked
+Status: locked as drafted. Co-author sign-off pending.

--- a/paper/02-literature/literature-map.md
+++ b/paper/02-literature/literature-map.md
@@ -71,7 +71,22 @@ That's the paper.
 
 ## 2.4 The related-work paragraph
 
-Write this last, once the table is full. About 150 words. Cover A, B and C, then
-name the gap. Don't pad it.
+Draft, about 160 words. Tighten once the reading log is full.
 
-Status: areas scoped / reading log filled / gap paragraph written
+Three literatures bear on this paper, and none of them does what we do. The
+first measures AI exposure, meaning which occupations are at risk: Felten, Raj
+and Seamans (2021), Eloundou et al. (2023), Brynjolfsson et al. (2018), the
+ILO's 2025 refined index, and Massenkoff and McCrory's (2026) observed-exposure
+measure. It tells you where risk concentrates, not whether it has landed. The
+second documents the effects that have already landed: Brynjolfsson, Chandar and
+Chen (2025) find a roughly 16 percent relative employment drop for young workers
+in exposed jobs, and Frank, Ahn and Moro (2025), our closest neighbor, join
+exposure scores to state-by-occupation unemployment risk. But Frank et al. use
+exposure against realized claims, treat it contemporaneously, and stop in 2019,
+before ChatGPT. The third nowcasts unemployment from search (Choi and Varian
+2012; Grybauskas et al. 2023) and finds distress searches can lead claims.
+Nobody has joined a high-frequency household financial-stress search signal to
+AI exposure and tested it as a leading indicator of occupational unemployment in
+the generative-AI period. That is this paper.
+
+Status: gap paragraph drafted. Reading log still to be filled as we read.

--- a/paper/03-preregistration/preregistration.md
+++ b/paper/03-preregistration/preregistration.md
@@ -12,9 +12,12 @@ search inputs can be built first. The outcome waits.
 ## 3.1 Hypotheses
 
 - H1, the main one. The joined AI-distress signal at time t is positively
-  related to realized occupational unemployment at t plus k, with k between one
-  and three months, in high-exposure occupations.
-- H2, the placebo. No such lead shows up in low-exposure occupations.
+  related to realized occupational unemployment at t plus k, with k of 1, 2 and
+  3 months, in high-exposure occupations (top tercile of the composite).
+  Operationally: the sum of the distributed-lead coefficients over k is positive
+  at the threshold in 3.3.
+- H2, the placebo. No such lead shows up in low-exposure occupations (bottom
+  tercile).
 - H3, optional. Augmentation-coded search terms don't predict unemployment.
   Substitution-coded terms do.
 
@@ -24,17 +27,31 @@ search inputs can be built first. The outcome waits.
   equal-weighted by default. State rollup uses OEWS employment shares, formula
   in brief section 3.1.
 - Search signal. The ontology from brief section 3.2, normalized as divergence
-  from baseline. Set the baseline window here: trailing ___ months.
-- Outcome. BLS occupational unemployment or LAUS. Fix the reference period and
-  the vintage now.
-- High-exposure cutoff. Top third or top quarter of the composite.
+  from a trailing 52-week baseline, with robustness at 26 and 104 weeks. We pull
+  the search series from January 2022 so the divergence is well-defined from the
+  first test month.
+- Outcome. The unemployment rate for each state, occupation cluster, and month,
+  from CPS microdata (IPUMS-CPS), on a 3-month rolling basis. The reference
+  period is the survey month. We fix the vintage to first release so revisions
+  can't move the result. LAUS state unemployment and national unemployment by
+  occupation cluster are the robustness brackets.
+- High-exposure cutoff. Top tercile of the composite, employment-weighted across
+  detailed occupations. The bottom tercile is the placebo group for H2.
 
 ## 3.3 Analysis plan (name the statistic and the threshold)
 
-- The primary test: cross-correlation at lag k, panel regression with leads, or
-  an out-of-sample nowcast against an AR baseline.
-- Decision threshold: ___.
-- How we handle multiple comparisons across states and clusters: ___.
+- The primary test. A panel distributed-lead regression: occupational
+  unemployment at t+k on the standardized signal at t, with leads at k of 1, 2
+  and 3, state-by-cluster and month fixed effects, and standard errors clustered
+  by state and by occupation cluster. The decision statistic is the sum of the
+  three lead coefficients.
+- Decision threshold. The lead-coefficient sum is positive at p < 0.05
+  (two-sided). We also pre-specify an out-of-sample check: the signal-augmented
+  model beats an AR baseline on RMSE at horizon k in a rolling-window evaluation.
+- Multiple comparisons. There is exactly one confirmatory test, the pooled
+  high-exposure lead-coefficient sum. Every by-state, by-cluster and by-k
+  breakout is secondary and reported with Benjamini-Hochberg FDR control at
+  q of 0.10, labeled exploratory.
 
 ## 3.4 Kill condition (from brief section 5)
 
@@ -48,18 +65,26 @@ We decide this now, while we still don't know the answer. That's the point.
 
 ## 3.5 Exclusions and suppression (set in advance)
 
-- Suppress any state by occupation cell below employment count N of ___.
-- Flag any search series below volume floor ___ as low confidence.
+- Suppress any state, occupation cluster, and month cell with fewer than 50
+  labor-force respondents in the 3-month pooled window.
+- Flag, but do not drop, any search series below its volume floor: a state-week
+  below the 10th percentile of that term's national distribution is
+  low-confidence. Drop a series only if it is zero or near-zero for more than
+  half the window. We can tighten these floors after seeing the volume
+  distributions, never loosen them, and we document any change.
 
 ## 3.6 Sample and period
 
-- States: all 50 plus DC. Period: ___ to ___. Frequency: monthly or quarterly.
+- States: all 50 plus DC. Test window: January 2023 (post-ChatGPT, the
+  generative-AI period) to the data-freeze month. Search series pulled from
+  January 2022 for the baseline. Frequency: monthly.
 
 ## 3.7 Registration record
 
-- Platform: OSF Registries or AsPredicted.
-- URL: ___
-- Timestamp: ___
-- Frozen commit of this file: ___
+- Platform: OSF Registries (preferred for the full design) or AsPredicted.
+- URL: ___ (fill on posting)
+- Timestamp: ___ (fill on posting)
+- Frozen commit of this file: ___ (the commit hash of the posted version)
 
-Status: drafted / co-author sign-off / posted with timestamp
+Status: drafted. Co-author sign-off and posting still to come. Do not pull the
+CPS outcome data until this is posted with a timestamp.

--- a/paper/README.md
+++ b/paper/README.md
@@ -35,9 +35,9 @@ and 5 are the real work, and everything else waits on them.
 
 ## Where we are
 
-- [ ] 1. Claim locked. One sentence we both agree on.
-- [ ] 2. Literature mapped. Gap written, about 20 sources read.
-- [ ] 3. Pre-registration posted. Timestamp in hand.
+- [x] 1. Claim locked as drafted. One sentence, fully operationalized. Co-author sign-off pending.
+- [ ] 2. Literature mapped. Gap paragraph drafted; full reading (about 20 sources) still to do.
+- [ ] 3. Pre-registration drafted and ready for sign-off. Not yet posted, no timestamp.
 - [ ] 4. Data assembled and frozen. Versioned snapshot and dictionary.
 - [ ] 5. Analysis run. Headline result and robustness done.
 - [ ] 6. Manuscript drafted. Full draft through the limitations.


### PR DESCRIPTION
Step 1: lock the one-sentence claim with all four decisions resolved (lead window k=1-3, CPS occupational unemployment as the outcome with LAUS/national-by-cluster as robustness, top-tercile high-exposure cutoff, distributed-lead coefficient sum as the headline statistic).

Step 2: draft the ~160-word related-work gap paragraph covering the three literatures and naming the gap.

Step 3: fill in every pre-registration decision point (baseline window, outcome and vintage, exposure cutoff, primary test and threshold, multiple comparisons, suppression rules, sample and period). Left as a draft pending co-author sign-off and posting; outcome data stays untouched until posted.

Update the paper README checklist to reflect this progress.

https://claude.ai/code/session_01DefMn8Sm8Akt65DtTpRGjx